### PR TITLE
Make mongoose-auth comply with a recent everyauth commit.

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,10 +75,10 @@ exports = module.exports = function plugin (schema, opts) {
 
   // Delegate middleware method to
   // everyauth's middleware method
-  exports.middleware = everyauth.middleware;
+  exports.middleware = everyauth.middleware.bind(everyauth);
 
   // Delegate helpExpress method to everyauth.
   // Adds dynamic helpers such as loggedIn,
   // accessible from the views
-  exports.helpExpress = everyauth.helpExpress;
+  exports.helpExpress = everyauth.helpExpress.bind(everyauth);
 };


### PR DESCRIPTION
A recent commit to everyauth
https://github.com/bnoguchi/everyauth/commit/383b48d9f0fc9d0d9771123950e94f77ab2e27c4
changed the way the expressHelper and connect middleware work.
Basically, a change was made that assumed that the 'middleware' and
'helpExpress' methods  would always be called with 'this' bound to
'everyauth'. Of course, this rendered the mongoose-auth  version
ineffective. This commit fixes this problem.
