### PR TITLE
loginWith must be specified for password auth 

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ Here is an example, using 5 authorization strategies:
               , registerView: 'register.jade'
               , loginSuccessRedirect: '/'
               , registerSuccessRedirect: '/'
+              , loginWith: 'login'
             }
         }
       , github: {


### PR DESCRIPTION
Password auth didn't work for me without specifying `loginWith: 'login'`

See https://github.com/bnoguchi/everyauth/issues/54

I didn't try running the example. It might have to be changed too.
