### PR TITLE
facebook alias property fix

### DIFF
--- a/lib/modules/facebook/schema.js
+++ b/lib/modules/facebook/schema.js
@@ -8,7 +8,7 @@ module.exports = {
         , first: String
         , last: String
       }
-    , fbAlias: String
+    , alias: String
     , gender: String
     , email: String
 //      , email: Email // TODO Try to add Email type back in


### PR DESCRIPTION
facebook: fixing invalid reference to fbAlias, renamed to 'alias' as outlined in plugins.js. Adding to mongoose db works correctly however calling fb.alias results in undefined due to schema mismatch.
