### PR TITLE
Add Google to the list of providers in the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ mongoose-auth supports the following authorization strategies:
 - `twitter`
 - `github`
 - `instagram`
+- `google`
 
 mongoose-auth does 3 things:
 


### PR DESCRIPTION
Saw you added it to the repo (and in the example), but didn't see it on the README.
