### PR TITLE
Update bcrypt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,4 @@
 test:
-	@expresso test/authplugin.test.js
+	@node_modules/.bin/mocha
 
-test-cov:
-	@TESTFLAGS=--cov $(MAKE) test
-
-.PHONY: test test-cov
+.PHONY: test

--- a/lib/modules/password/plugin.js
+++ b/lib/modules/password/plugin.js
@@ -36,8 +36,8 @@ exports = module.exports = function (schema, opts) {
     return this._password;
   }).set( function (password) {
     this._password = password;
-    var salt = this.salt = bcrypt.gen_salt_sync(10);
-    this.hash = bcrypt.encrypt_sync(password, salt);
+    var salt = this.salt = bcrypt.genSaltSync(10);
+    this.hash = bcrypt.hashSync(password, salt);
   });
 
   schema.method('authenticate', function (password, callback) {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lib": "."
   },
   "dependencies": {
-    "bcrypt":">=0.2.0",
+    "bcrypt":">=0.5.0",
     "mongoose": ">=1.4.0",
     "everyauth": "0.2.23",
     "mongoose-types": ">=1.0.3"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,12 @@
   },
   "devDependencies": {
     "express": ">=2.3.2",
-    "jade": ">=0.12.1"
+    "jade": ">=0.12.1",
+    "mocha": ">=0.10.1",
+    "should": ">=0.5.1"
+  },
+  "scripts": {
+    "test": "make"
   },
   "engines": {
     "node": ">=0.4.0"

--- a/test/authplugin.test.js
+++ b/test/authplugin.test.js
@@ -11,8 +11,8 @@ UserSchema.plugin(authPlugin, {
 mongoose.model('User', UserSchema);
 User = mongoose.model('User');
 
-module.exports = {
-  "setting a user's password should generate a salt and set a hash": function () {
+describe('User', function () {
+  it('should generate a salt and set a hash when password is set', function () {
     var user = new User();
     should.strictEqual(undefined, user.salt);
     should.strictEqual(undefined, user.hash);
@@ -20,17 +20,21 @@ module.exports = {
     user.password.should.equal('hello');
     user.salt.should.not.be.undefined;
     user.hash.should.not.be.undefined;
-  },
-
-  'a user should authenticate with a correct password': function () {
+  });
+  it('should authenticate with a correct password', function (done) {
     var user = new User();
     user.password = 'hello';
-    user.authenticate('hello').should.be.true;
-  },
-
-  'a user should fail authentication with an incorrect password': function () {
+    user.authenticate('hello', function (err, matched) {
+      matched.should.be.true;
+      done();
+    });
+  });
+  it('should fail authentication with an incorrect password', function (done) {
     var user = new User();
     user.password = 'correct';
-    user.authenticate('incorrect').should.be.false;
-  }
-};
+    user.authenticate('incorrect', function (err, matched) {
+      matched.should.be.false;
+      done();
+    });
+  });
+});


### PR DESCRIPTION
Started getting deprecation warnings when I updated bcrypt to version 0.5.0. Looks like they changed their API a bit, so I've tidied that up in mongoose-auth.

I noticed the tests in the test folder covered the usage of bcrypt, but used expresso. I converted them to mocha (which is the spiritual successor to expresso by TJ) and set up the tests to be run with the `npm test` command.

Thanks!
