### PR TITLE
Report individual validator error messages for password registration

### DIFF
--- a/lib/modules/password/everyauth.js
+++ b/lib/modules/password/everyauth.js
@@ -28,7 +28,14 @@ module.exports = {
       , user = new User(newUserAttrs);
     user.validate( function (err) {
       if (err) {
-        errors.push(err.message || err);
+        if ('errors' in err) {
+          for (var path in err.errors) {
+            errors.push(err.errors[path].message || err.errors[path]);
+          }
+        }
+        else {
+          errors.push(err.message || err);
+        }
       }
       if (errors.length)
         return promise.fulfill(errors);


### PR DESCRIPTION
When registering with a password fails due to any number of validation errors, The errors array only contains "Validation failed", even though the ValidationError it is constructed from had more specific diagnostic information available.

Here is a patch to include the message from each ValidatorError of the ValidationError when collecting error messages to be sent to the client.
