### PR TITLE
Update support

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ var Modules = {
   , github: require('./lib/modules/github')
   , instagram: require('./lib/modules/instagram')
   , google: require('./lib/modules/google')
+  , dwolla: require('./lib/modules/dwolla')
 };
 
 // Mostly, we need this because password needs to be loaded before everything else
@@ -54,8 +55,8 @@ exports = module.exports = function plugin (schema, opts) {
       if (!everyauthConfig[k])
         everyauthConfig[k] = everyauthDefaults[k];
     }
-   
-    // Configure everyauth for this module 
+
+    // Configure everyauth for this module
     for (var k in everyauthConfig) {
       everyauth[moduleName][k]( everyauthConfig[k] );
     }

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ var Modules = {
 
 // Mostly, we need this because password needs to be loaded before everything else
 // so that other modules can use everyauth.password.loginKey()
-var moduleLoadOrder = ['everymodule', 'password', 'facebook', 'twitter', 'github', 'instagram', 'google'];
+var moduleLoadOrder = ['everymodule', 'password', 'facebook', 'twitter', 'github', 'instagram', 'google', 'dwolla'];
 
 /**
  * Decorates the (User) Schema with the proper attributes.

--- a/lib/modules/dwolla/everyauth.js
+++ b/lib/modules/dwolla/everyauth.js
@@ -1,0 +1,23 @@
+// Defaults
+module.exports = {
+  findOrCreateUser: function (sess, accessTok, accessTokExtra, dUser) {
+    var promise = this.Promise()
+      , User = this.User()();
+    // TODO Check user in session or request helper first
+    //      e.g., req.user or sess.auth.userId
+    User.findOne({'dwolla.id': dUser.Id}, function (err, foundUser) {
+      if (foundUser) {
+        foundUser.updateDwollaData(dUser, accessTok, accessTokExtra.expires, function (err, foundUser){
+          if (err) return promise.fail(err);
+          return promise.fulfill(foundUser);
+        });
+      } else {
+        User.createWithDwolla(dUser, accessTok, accessTokExtra.expires, function (err, createdUser) {
+          if (err) return promise.fail(err);
+          return promise.fulfill(createdUser);
+        });
+      }
+    });
+    return promise;
+  }
+};

--- a/lib/modules/dwolla/everyauth.js
+++ b/lib/modules/dwolla/everyauth.js
@@ -7,12 +7,12 @@ module.exports = {
     //      e.g., req.user or sess.auth.userId
     User.findOne({'dwolla.id': dUser.Id}, function (err, foundUser) {
       if (foundUser) {
-        foundUser.updateDwollaData(dUser, accessTok, accessTokExtra.expires, function (err, foundUser){
+        foundUser.updateDwollaData(dUser, accessTok, function (err, foundUser){
           if (err) return promise.fail(err);
           return promise.fulfill(foundUser);
         });
       } else {
-        User.createWithDwolla(dUser, accessTok, accessTokExtra.expires, function (err, createdUser) {
+        User.createWithDwolla(dUser, accessTok, function (err, createdUser) {
           if (err) return promise.fail(err);
           return promise.fulfill(createdUser);
         });

--- a/lib/modules/dwolla/index.js
+++ b/lib/modules/dwolla/index.js
@@ -1,0 +1,3 @@
+exports.schema = require('./schema');
+exports.plugin = require('./plugin');
+exports.everyauth = require('./everyauth');

--- a/lib/modules/dwolla/plugin.js
+++ b/lib/modules/dwolla/plugin.js
@@ -5,15 +5,12 @@ var mongoose = require('mongoose')
 module.exports = function dwolla(schema, opts) {
   schema.add(_schema);
 
-  schema.static('createWithDwolla', function (dUserMeta, accessToken, expires, callback) {
-    var expiresDate = new Date();
-    expiresDate.setSeconds(expiresDate.getSeconds() + expires);
+  schema.static('createWithDwolla', function (dUserMeta, accessToken, callback) {
 
     var params =  {
       dwolla: {
         id          : dUserMeta.Id
       , accessToken : accessToken
-      , expires     : expiresDate
       , city        : dUserMeta.City
       , latitude    : dUserMeta.Latitude
       , longitude   : dUserMeta.Longitude
@@ -31,15 +28,12 @@ module.exports = function dwolla(schema, opts) {
     this.create(params, callback);
   });
 
-  schema.method('updateDwollaData', function (dUserMeta, accessToken, expires, callback) {
+  schema.method('updateDwollaData', function (dUserMeta, accessToken, callback) {
     var foundUser = this;
-    var expiresDate = new Date();
-    expiresDate.setSeconds(expiresDate.getSeconds() + expires);
 
     foundUser.dwolla = {
         id          : dUserMeta.Id
       , accessToken : accessToken
-      , expires     : expiresDate
       , city        : dUserMeta.City
       , latitude    : dUserMeta.Latitude
       , longitude   : dUserMeta.Longitude

--- a/lib/modules/dwolla/plugin.js
+++ b/lib/modules/dwolla/plugin.js
@@ -1,0 +1,55 @@
+var mongoose = require('mongoose')
+  , _schema = require('./schema')
+  , everyauth = require('everyauth');
+
+module.exports = function dwolla(schema, opts) {
+  schema.add(_schema);
+
+  schema.static('createWithDwolla', function (dUserMeta, accessToken, expires, callback) {
+    var expiresDate = new Date();
+    expiresDate.setSeconds(expiresDate.getSeconds() + expires);
+
+    var params =  {
+      dwolla: {
+        id          : dUserMeta.Id
+      , accessToken : accessToken
+      , expires     : expiresDate
+      , city        : dUserMeta.City
+      , latitude    : dUserMeta.Latitude
+      , longitude   : dUserMeta.Longitude
+      , name        : dUserMeta.Name
+      , state       : dUserMeta.State
+      , type        : dUserMeta.Type
+      }
+    };
+
+    // TODO Only do this if password module is enabled
+    //      Currently, this is not a valid way to check for enabled
+    if (everyauth.password)
+      params[everyauth.password.loginKey()] = "dwolla:" + dUserMeta.Id; // Hack because of way mongodb treate unique indexes
+
+    this.create(params, callback);
+  });
+
+  schema.method('updateDwollaData', function (dUserMeta, accessToken, expires, callback) {
+    var foundUser = this;
+    var expiresDate = new Date();
+    expiresDate.setSeconds(expiresDate.getSeconds() + expires);
+
+    foundUser.dwolla = {
+        id          : dUserMeta.Id
+      , accessToken : accessToken
+      , expires     : expiresDate
+      , city        : dUserMeta.City
+      , latitude    : dUserMeta.Latitude
+      , longitude   : dUserMeta.Longitude
+      , name        : dUserMeta.Name
+      , state       : dUserMeta.State
+      , type        : dUserMeta.Type
+    };
+
+    foundUser.save(function(err){
+      callback(err, foundUser);
+    });
+  });
+};

--- a/lib/modules/dwolla/schema.js
+++ b/lib/modules/dwolla/schema.js
@@ -2,7 +2,6 @@ module.exports = {
   dwolla: {
       id          : String
     , accessToken : String
-    , expires     : Date
     , city        : String
     , latitude    : Number
     , longitude   : Number

--- a/lib/modules/dwolla/schema.js
+++ b/lib/modules/dwolla/schema.js
@@ -1,0 +1,13 @@
+module.exports = {
+  dwolla: {
+      id          : String
+    , accessToken : String
+    , expires     : Date
+    , city        : String
+    , latitude    : Number
+    , longitude   : Number
+    , name        : String
+    , state       : String
+    , type        : {type:String,"enum":[null,'Personal','Commercial','Nonprofit']}
+  }
+};

--- a/lib/modules/facebook/everyauth.js
+++ b/lib/modules/facebook/everyauth.js
@@ -6,6 +6,7 @@ module.exports = {
     // TODO Check user in session or request helper first
     //      e.g., req.user or sess.auth.userId
     User.findOne({'fb.id': fbUser.id}, function (err, foundUser) {
+      if (err) return promise.fail(err);
       if (foundUser) {
         foundUser.updateFBData(fbUser, accessTok, accessTokExtra.expires, function (err, foundUser){
           if (err) return promise.fail(err);

--- a/lib/modules/facebook/everyauth.js
+++ b/lib/modules/facebook/everyauth.js
@@ -7,13 +7,17 @@ module.exports = {
     //      e.g., req.user or sess.auth.userId
     User.findOne({'fb.id': fbUser.id}, function (err, foundUser) {
       if (foundUser) {
-        return promise.fulfill(foundUser);
+        foundUser.updateFBData(fbUser, accessTok, accessTokExtra.expires, function (err, foundUser){
+          if (err) return promise.fail(err);
+          return promise.fulfill(foundUser);
+        });
+      } else {
+        console.log("Created Facebook User:" + fbUser.name);
+        User.createWithFB(fbUser, accessTok, accessTokExtra.expires, function (err, createdUser) {
+          if (err) return promise.fail(err);
+          return promise.fulfill(createdUser);
+        });
       }
-      console.log("CREATING");
-      User.createWithFB(fbUser, accessTok, accessTokExtra.expires, function (err, createdUser) {
-        if (err) return promise.fail(err);
-        return promise.fulfill(createdUser);
-      });
     });
     return promise;
   }

--- a/lib/modules/facebook/everyauth.js
+++ b/lib/modules/facebook/everyauth.js
@@ -12,7 +12,6 @@ module.exports = {
           return promise.fulfill(foundUser);
         });
       } else {
-        console.log("Created Facebook User:" + fbUser.name);
         User.createWithFB(fbUser, accessTok, accessTokExtra.expires, function (err, createdUser) {
           if (err) return promise.fail(err);
           return promise.fulfill(createdUser);

--- a/lib/modules/facebook/plugin.js
+++ b/lib/modules/facebook/plugin.js
@@ -22,7 +22,7 @@ module.exports = function facebook (schema, opts) {
             , first: fbUserMeta.first_name
             , last: fbUserMeta.last_name
           }
-        , alias: fbUserMeta.link.match(/^http:\/\/www.facebook\.com\/(.+)/)[1]
+        , alias: fbUserMeta.link ? fbUserMeta.link.match(/^http:\/\/www.facebook\.com\/(.+)/)[1] : ''
         , gender: fbUserMeta.gender
         , email: fbUserMeta.email
         , timezone: fbUserMeta.timezone
@@ -40,7 +40,7 @@ module.exports = function facebook (schema, opts) {
 
     this.create(params, callback);
   });
-  
+
   schema.method('updateFBData', function (fbUserMeta, accessToken, expires, callback) {
     var foundUser = this;
     var expiresDate = new Date();
@@ -65,14 +65,14 @@ module.exports = function facebook (schema, opts) {
         , isNew: false
       }
     };
-    
+
     foundUser.fb = params.fb;
 
     // TODO Only do this if password module is enabled
     //      Currently, this is not a valid way to check for enabled
     if (everyauth.password)
       params[everyauth.password.loginKey()] = "fb:" + fbUserMeta.id; // Hack because of way mongodb treate unique indexes
-      
+
     foundUser.save(function(err){
       callback(err, foundUser);
     });

--- a/lib/modules/facebook/plugin.js
+++ b/lib/modules/facebook/plugin.js
@@ -39,4 +39,40 @@ module.exports = function facebook (schema, opts) {
 
     this.create(params, callback);
   });
+  
+  schema.method('updateFBData', function (fbUserMeta, accessToken, expires, callback) {
+    var foundUser = this;
+    var expiresDate = new Date;
+    expiresDate.setSeconds(expiresDate.getSeconds() + expires);
+    var params =  {
+      fb: {
+          id: fbUserMeta.id
+        , accessToken: accessToken
+        , expires: expiresDate
+        , name: {
+              full: fbUserMeta.name
+            , first: fbUserMeta.first_name
+            , last: fbUserMeta.last_name
+          }
+        , alias: fbUserMeta.link.match(/^http:\/\/www.facebook\.com\/(.+)/)[1]
+        , gender: fbUserMeta.gender
+        , email: fbUserMeta.email
+        , timezone: fbUserMeta.timezone
+        , locale: fbUserMeta.locale
+        , verified: fbUserMeta.verified
+        , updatedTime: fbUserMeta.updated_time
+      }
+    };
+    
+    foundUser.fb = params.fb;
+
+    // TODO Only do this if password module is enabled
+    //      Currently, this is not a valid way to check for enabled
+    if (everyauth.password)
+      params[everyauth.password.loginKey()] = "fb:" + fbUserMeta.id; // Hack because of way mongodb treate unique indexes
+      
+    foundUser.save(function(err){
+      callback(err, foundUser);
+    });
+  });
 };

--- a/lib/modules/facebook/plugin.js
+++ b/lib/modules/facebook/plugin.js
@@ -9,7 +9,7 @@ module.exports = function facebook (schema, opts) {
   schema.add(_schema);
 
   schema.static('createWithFB', function (fbUserMeta, accessToken, expires, callback) {
-    var expiresDate = new Date;
+    var expiresDate = new Date();
     expiresDate.setSeconds(expiresDate.getSeconds() + expires);
 
     var params =  {
@@ -29,6 +29,7 @@ module.exports = function facebook (schema, opts) {
         , locale: fbUserMeta.locale
         , verified: fbUserMeta.verified
         , updatedTime: fbUserMeta.updated_time
+        , isNew: true
       }
     };
 
@@ -42,7 +43,7 @@ module.exports = function facebook (schema, opts) {
   
   schema.method('updateFBData', function (fbUserMeta, accessToken, expires, callback) {
     var foundUser = this;
-    var expiresDate = new Date;
+    var expiresDate = new Date();
     expiresDate.setSeconds(expiresDate.getSeconds() + expires);
     var params =  {
       fb: {
@@ -61,6 +62,7 @@ module.exports = function facebook (schema, opts) {
         , locale: fbUserMeta.locale
         , verified: fbUserMeta.verified
         , updatedTime: fbUserMeta.updated_time
+        , isNew: false
       }
     };
     

--- a/lib/modules/facebook/schema.js
+++ b/lib/modules/facebook/schema.js
@@ -18,5 +18,6 @@ module.exports = {
     , verified: Boolean
     , updatedTime: String
     , phone: String
+    , isNew: Boolean
   }
 };


### PR DESCRIPTION
Added update support for Facebook: subsequent logins will update stored access_token and fb metadata.

I noticed the FB data stored by mongoose-auth on first login quickly becomes stale.  This addition to findOrCreateUser will update the stored data with new data when available.
