### PR TITLE
In order for this example to run out of the box (Given mongooseAuth's im...

### DIFF
--- a/example/server.js
+++ b/example/server.js
@@ -62,7 +62,8 @@ UserSchema.plugin(mongooseAuth, {
     }
   , github: {
       everyauth: {
-          myHostname: 'http://local.host:3000'
+          scope: 'user'
+        ,  myHostname: 'http://local.host:3000'
         , appId: conf.github.appId
         , appSecret: conf.github.appSecret
         , redirectPath: '/'


### PR DESCRIPTION
...plicit private user data dependency, see Issue #93), at least a user scope must be provided for github
