### PR TITLE
Facebook update support

### DIFF
--- a/lib/modules/facebook/everyauth.js
+++ b/lib/modules/facebook/everyauth.js
@@ -6,6 +6,7 @@ module.exports = {
     // TODO Check user in session or request helper first
     //      e.g., req.user or sess.auth.userId
     User.findOne({'fb.id': fbUser.id}, function (err, foundUser) {
+      if (err) return promise.fail(err);
       if (foundUser) {
         foundUser.updateFBData(fbUser, accessTok, accessTokExtra.expires, function (err, foundUser){
           if (err) return promise.fail(err);

--- a/lib/modules/facebook/everyauth.js
+++ b/lib/modules/facebook/everyauth.js
@@ -7,13 +7,17 @@ module.exports = {
     //      e.g., req.user or sess.auth.userId
     User.findOne({'fb.id': fbUser.id}, function (err, foundUser) {
       if (foundUser) {
-        return promise.fulfill(foundUser);
+        foundUser.updateFBData(fbUser, accessTok, accessTokExtra.expires, function (err, foundUser){
+          if (err) return promise.fail(err);
+          return promise.fulfill(foundUser);
+        });
+      } else {
+        console.log("Created Facebook User:" + fbUser.name);
+        User.createWithFB(fbUser, accessTok, accessTokExtra.expires, function (err, createdUser) {
+          if (err) return promise.fail(err);
+          return promise.fulfill(createdUser);
+        });
       }
-      console.log("CREATING");
-      User.createWithFB(fbUser, accessTok, accessTokExtra.expires, function (err, createdUser) {
-        if (err) return promise.fail(err);
-        return promise.fulfill(createdUser);
-      });
     });
     return promise;
   }

--- a/lib/modules/facebook/plugin.js
+++ b/lib/modules/facebook/plugin.js
@@ -39,4 +39,40 @@ module.exports = function facebook (schema, opts) {
 
     this.create(params, callback);
   });
+  
+  schema.method('updateFBData', function (fbUserMeta, accessToken, expires, callback) {
+    var foundUser = this;
+    var expiresDate = new Date;
+    expiresDate.setSeconds(expiresDate.getSeconds() + expires);
+    var params =  {
+      fb: {
+          id: fbUserMeta.id
+        , accessToken: accessToken
+        , expires: expiresDate
+        , name: {
+              full: fbUserMeta.name
+            , first: fbUserMeta.first_name
+            , last: fbUserMeta.last_name
+          }
+        , alias: fbUserMeta.link.match(/^http:\/\/www.facebook\.com\/(.+)/)[1]
+        , gender: fbUserMeta.gender
+        , email: fbUserMeta.email
+        , timezone: fbUserMeta.timezone
+        , locale: fbUserMeta.locale
+        , verified: fbUserMeta.verified
+        , updatedTime: fbUserMeta.updated_time
+      }
+    };
+    
+    foundUser.fb = params.fb;
+
+    // TODO Only do this if password module is enabled
+    //      Currently, this is not a valid way to check for enabled
+    if (everyauth.password)
+      params[everyauth.password.loginKey()] = "fb:" + fbUserMeta.id; // Hack because of way mongodb treate unique indexes
+      
+    foundUser.save(function(err){
+      callback(err, foundUser);
+    });
+  });
 };

--- a/lib/modules/facebook/plugin.js
+++ b/lib/modules/facebook/plugin.js
@@ -9,7 +9,7 @@ module.exports = function facebook (schema, opts) {
   schema.add(_schema);
 
   schema.static('createWithFB', function (fbUserMeta, accessToken, expires, callback) {
-    var expiresDate = new Date;
+    var expiresDate = new Date();
     expiresDate.setSeconds(expiresDate.getSeconds() + expires);
 
     var params =  {
@@ -29,6 +29,7 @@ module.exports = function facebook (schema, opts) {
         , locale: fbUserMeta.locale
         , verified: fbUserMeta.verified
         , updatedTime: fbUserMeta.updated_time
+        , isNew: true
       }
     };
 
@@ -42,7 +43,7 @@ module.exports = function facebook (schema, opts) {
   
   schema.method('updateFBData', function (fbUserMeta, accessToken, expires, callback) {
     var foundUser = this;
-    var expiresDate = new Date;
+    var expiresDate = new Date();
     expiresDate.setSeconds(expiresDate.getSeconds() + expires);
     var params =  {
       fb: {
@@ -61,6 +62,7 @@ module.exports = function facebook (schema, opts) {
         , locale: fbUserMeta.locale
         , verified: fbUserMeta.verified
         , updatedTime: fbUserMeta.updated_time
+        , isNew: false
       }
     };
     

--- a/lib/modules/facebook/schema.js
+++ b/lib/modules/facebook/schema.js
@@ -18,5 +18,6 @@ module.exports = {
     , verified: Boolean
     , updatedTime: String
     , phone: String
+    , isNew: Boolean
   }
 };


### PR DESCRIPTION
Added update support for Facebook: subsequent logins will update stored access_token and fb metadata.

I noticed the FB data stored by mongoose-auth on first login quickly becomes stale. This addition to findOrCreateUser will update the stored data with new data when available.

I also added an 'isNew' field to the schema as well. This is true if and only if the user is completely fresh. We use this locally for asking the user to verify certain data, e.g. email address.
