### PR TITLE
exclude hash and salt fields from queries by default

### DIFF
--- a/lib/modules/password/plugin.js
+++ b/lib/modules/password/plugin.js
@@ -51,14 +51,23 @@ exports = module.exports = function (schema, opts) {
 exports.authenticate = function (login, password, callback) {
   // TODO This will break if we change everyauth's
   //      configurable loginName
-  var query = {};
+  var query = {}
+    , paths = this.prototype._schema.paths
+    , fields = Object.keys(paths)
+    , deselected = fields.filter(function (field) {
+      return paths[field].options && paths[field].options.select === false;
+    });
   query[everyauth.password.loginKey()] = login;
-  this.findOne(query, function (err, user) {
+  this.findOne(query, fields, function (err, user) {
     if (err) return callback(err);
     if (!user) return callback('User with login ' + login + ' does not exist');
     user.authenticate(password, function (err, didSucceed) {
       if (err) return callback(err);
-      if (didSucceed) return callback(null, user);
+      if (didSucceed) {
+        deselected.forEach(function (field) { user[field] = undefined; });
+        user._reset();
+        return callback(null, user);
+      }
       return callback(null, null);
     });
   });

--- a/lib/modules/password/schema.js
+++ b/lib/modules/password/schema.js
@@ -1,5 +1,5 @@
 module.exports = {
     login: { type: String, unique: true }
-  , salt: String
-  , hash: String
+  , salt: { type: String, select: false }
+  , hash: { type: String, select: false }
 };


### PR DESCRIPTION
Besides potentially posing a security risk, returning hash and salt fields add a lot of weight to JSON responses. Rather than excluding the fields in _all_ of my queries, I decided to make these two fields `select: false` by default. If you find this useul, feel free to pull. :)

furf
