### PR TITLE
Fixed to work with mongoose 3.x

### DIFF
--- a/example/server.js
+++ b/example/server.js
@@ -9,7 +9,12 @@ everyauth.debug = true;
 
 var mongoose = require('mongoose')
   , Schema = mongoose.Schema
-  , ObjectId = mongoose.SchemaTypes.ObjectId;
+  , ObjectId;
+
+if (mongoose.SchemaTypes !== undefined)
+  ObjectId = mongoose.SchemaTypes.ObjectId;
+else
+  ObjectId = mongoose.Schema.Types.ObjectId;
 
 var UserSchema = new Schema({})
   , User;

--- a/lib/modules/facebook/plugin.js
+++ b/lib/modules/facebook/plugin.js
@@ -3,7 +3,11 @@ var mongoose = require('mongoose')
   , _schema = require('./schema')
   , everyauth = require('everyauth');
 mongooseTypes.loadTypes(mongoose);
-var Email = mongoose.SchemaTypes.Email;
+var Email;
+if (mongoose.SchemaTypes !== undefined)
+  Email = mongoose.SchemaTypes.Email;
+else
+  Email = mongoose.Schema.Types.Email;
 
 module.exports = function facebook (schema, opts) {
   schema.add(_schema);

--- a/lib/modules/github/plugin.js
+++ b/lib/modules/github/plugin.js
@@ -3,7 +3,11 @@ var mongoose = require('mongoose')
   , _schema = require('./schema')
   , everyauth = require('everyauth');
 mongooseTypes.loadTypes(mongoose);
-var Email = mongoose.SchemaTypes.Email;
+var Email;
+if (mongoose.SchemaTypes !== undefined)
+  Email = mongoose.SchemaTypes.Email;
+else
+  Email = mongoose.Schema.Types.Email;
 
 module.exports = function github (schema, opts) {
   schema.add(_schema);

--- a/lib/modules/instagram/plugin.js
+++ b/lib/modules/instagram/plugin.js
@@ -3,7 +3,11 @@ var mongoose = require('mongoose')
   , _schema = require('./schema')
   , everyauth = require('everyauth');
 mongooseTypes.loadTypes(mongoose);
-var Email = mongoose.SchemaTypes.Email;
+var Email;
+if (mongoose.SchemaTypes !== undefined)
+  Email = mongoose.SchemaTypes.Email;
+else
+  Email = mongoose.Schema.Types.Email;
 
 module.exports = function instagram (schema, opts) {
   schema.add(_schema);

--- a/lib/modules/twitter/plugin.js
+++ b/lib/modules/twitter/plugin.js
@@ -3,7 +3,11 @@ var mongoose = require('mongoose')
   , _schema = require('./schema')
   , everyauth = require('everyauth');
 mongooseTypes.loadTypes(mongoose);
-var Url = mongoose.SchemaTypes.Url;
+var Url;
+if (mongoose.SchemaTypes !== undefined)
+  Url = mongoose.SchemaTypes.Url;
+else
+  Url = mongoose.Schema.Types.Url;
 
 // See http://dev.twitter.com/doc/get/users/show
 module.exports = function twitter (schema, opts) {


### PR DESCRIPTION
It uses mongoose.Schema.Types (mongoose 3.x) when mongoose.SchemaTypes is not available.
