### PR TITLE
decrease windows dependency by changing from bcrypt to bcrypt-nodejs

### DIFF
--- a/lib/modules/password/plugin.js
+++ b/lib/modules/password/plugin.js
@@ -23,7 +23,7 @@
 //
 //var sha1 = sha(1);
 
-var bcrypt = require('bcrypt')
+var bcrypt = require('bcrypt-nodejs')
   , _schema = require('./schema')
   , everyauth = require('everyauth')
   , authenticate;

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lib": "."
   },
   "dependencies": {
-    "bcrypt": ">=0.5.0",
+    "bcrypt-nodejs": ">=0.0.2",
     "mongoose": ">=2.4.8",
     "everyauth": ">=0.2.28",
     "mongoose-types": ">=1.0.3"


### PR DESCRIPTION
Hi,

bcrypt usage on Windows currently requires extensive installation of windows SDK, requiring gigabytes of downloads etc.

The newly-released bcrypt-nodejs offers an alternative without this requirement, while using essentially the same API.

In these commits, I propose a change bcrypt -> bcrypt-nodejs to support windows dev/deployment without ms visual studio / windows sdk dependency.

Thank you for considering this suggestion.
