### PR TITLE
Updated everyauth version to be compatible with Twitter API 1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
   "dependencies": {
     "bcrypt": ">=0.5.0",
     "mongoose": ">=2.4.8",
-    "everyauth": ">=0.2.28",
-    "mongoose-types": ">=1.0.3"
+    "mongoose-types": ">=1.0.3",
+    "everyauth": "~0.4.5"
   },
   "devDependencies": {
     "express": ">=2.3.2",


### PR DESCRIPTION
Hi @bnoguchi, 

I've just did a very simple change on mongoose-auth, a bump in the version of everyauth, so it uses twitter api 1.1 instead of 1.0.

I've run your tests and passed all 3 of them :) Also tried it to login with twitter manually and it's working like a charm.

:) 
